### PR TITLE
Remove local.properties from the repository and add to gitignore

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -32,3 +32,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+local.properties

--- a/examples/local.properties
+++ b/examples/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Tue Jul 08 20:37:00 EEST 2025
-sdk.dir=C\:\\Users\\lazar\\AppData\\Local\\Android\\Sdk

--- a/library/.gitignore
+++ b/library/.gitignore
@@ -32,3 +32,4 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Finder (MacOS) folder config
 .DS_Store
+local.properties

--- a/library/local.properties
+++ b/library/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Tue Jul 08 20:37:00 EEST 2025
-sdk.dir=C\:\\Users\\lazar\\AppData\\Local\\Android\\Sdk


### PR DESCRIPTION
The local.properties files contains information regarding the developer's environment and should not be added to git as they will differ for each user.

Currently these files expose machine-specific configurations (your username, for example). 

Team Clockworks, 19075